### PR TITLE
Prevent pre tags overflowing off the page

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -83,6 +83,7 @@ blockquote {
 
 pre {
   padding-left: 1.5rem;
+  overflow-x: auto;
 }
 
 table {


### PR DESCRIPTION
Fixes current homepage overflow bug
![image](https://user-images.githubusercontent.com/904501/65753595-e4d81100-e141-11e9-9429-c353131c7d69.png)
