### PR TITLE
fix suffixes

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,13 +14,13 @@ googleAnalytics = "UA-56802475-1"
 
 [mediaTypes]
 [mediaTypes."text/markdown"]
-suffix = "md"
+suffixes = ["md"]
 
 [mediaTypes."text/plain"]
-suffix = "txt"
+suffixes = ["txt"]
 
 [mediaTypes."text/asciidoc"]
-suffix = "adoc"
+suffixes = ["adoc"]
 
 [outputFormats]
 [outputFormats.Markdown]


### PR DESCRIPTION
MediaType.Suffix is removed. Before Hugo 0.44 this was used both to set a custom file suffix and as way to augment the mediatype definition (what you see after the "+", e.g. "image/svg+xml").

**In most cases, it will be enough to just change:**

[mediaTypes]
[mediaTypes."my/custom-mediatype"]
suffix = "txt"

To:

[mediaTypes]
[mediaTypes."my/custom-mediatype"]
suffixes = ["txt"]

TESTED with hugo version -> v0.55.6 