### PR TITLE
Remove truncation of text on datalist li

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -226,12 +226,6 @@ abbr {
   margin-left: 0;
 }
 
-.data-list li {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 .translations dt { display: none; }
 
 .icon {


### PR DESCRIPTION
Allow text to wrap naturally so project names don't get cut off
## Before
![image](https://user-images.githubusercontent.com/904501/66448206-6b1a1e80-ea83-11e9-9f43-2effc0435418.png)

## After
![image](https://user-images.githubusercontent.com/904501/66448237-7cfbc180-ea83-11e9-8986-2a19677ae56b.png)
